### PR TITLE
make install succeed even if dwgrep.1 is not built

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,15 @@
+version.h
 CMakeCache.txt
 CMakeFiles/
 CTestTestfile.cmake
 Makefile
 build/
 cmake_install.cmake
+install_manifest.txt
 doc/CMakeFiles/
 doc/_build/
 doc/_doctrees/
+doc/_source/
 doc/html/
 dwgrep
 dwgrep-gendoc

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -62,7 +62,7 @@ ADD_CUSTOM_TARGET (doc-man
     COMMENT "Building manual pages")
 
 INSTALL (FILES ${SPHINX_MAN_DIR}/dwgrep.1
-  DESTINATION share/man/man1)
+  DESTINATION share/man/man1 OPTIONAL)
 
 ADD_CUSTOM_TARGET (doc)
 ADD_DEPENDENCIES (doc doc-html doc-man)


### PR DESCRIPTION
Before this change, a simple "ccmake . ; make && make install" would fail due to dwgrep.1 not being built by default.