### PR TITLE
Include <functional> header for std::function

### DIFF
--- a/dwgrep/dwgrep.cc
+++ b/dwgrep/dwgrep.cc
@@ -31,6 +31,7 @@
 #include <cctype>
 #include <cstring>
 #include <fstream>
+#include <functional>
 #include <getopt.h>
 #include <iomanip>
 #include <iostream>


### PR DESCRIPTION
Hi Petr,

This is needed for GCC 7, due to the libstdc++ changes documented at https://gcc.gnu.org/gcc-7/porting_to.html#header-dep-changes